### PR TITLE
fixed double messages being received

### DIFF
--- a/client/controllers/chatcontroller.js
+++ b/client/controllers/chatcontroller.js
@@ -4,14 +4,13 @@ app.controller('ChatCtrl', function ($scope, $http, authService, chatService) {
   $scope.online_users=[];
   $scope.messageText="";
 
-
   $scope.getUser=function(){
     return authService.getUser();
   }
 
   $scope.sendMessage=function(){
     if($scope.messageText && $scope.messageText.contents && $scope.messageText.contents.trim().length>0){
-      chatService.emit('message', encodeURIComponent($scope.messageText.contents));
+      chatService.emit('messageToServer', encodeURIComponent($scope.messageText.contents));
       console.log('sent message');
       $scope.messageText="";
     }
@@ -21,12 +20,14 @@ app.controller('ChatCtrl', function ($scope, $http, authService, chatService) {
     $scope.messages.push("User "+username+" just joined.");
   });
 
-  chatService.on('message', function(payload){
+  chatService.on('messageFromServer', function(payload){
+    console.log('message from server', payload);
     $scope.messages.push({Author: payload.sender, Message:decodeURIComponent(payload.message)});
   });
 
-  chatService.on('userList', function(userlist){
-    $scope.online_users = userlist;
+  // makes sure all socket event listeners are removed after controller is destroyed
+  $scope.$on('$destroy', function (event){
+    chatService.removeAllListeners();
   });
 
 });

--- a/client/controllers/sidebarcontroller.js
+++ b/client/controllers/sidebarcontroller.js
@@ -17,7 +17,7 @@ app.directive('queue', function() {
 app.directive('userlist', function() {
   return {
     restrict: 'E',
-    controller: 'ChatCtrl',
+    controller: 'UserListCtrl',
 		templateUrl: 'views/users.html'
 	}
 });

--- a/client/controllers/userlistcontroller.js
+++ b/client/controllers/userlistcontroller.js
@@ -1,0 +1,23 @@
+app.controller('UserListCtrl', function ($scope, chatService) {
+  $scope.online_users=[];
+
+  chatService.on('userList', function(userlist){
+    $scope.online_users = userlist;
+  });
+
+  // makes sure all socket event listeners are removed after controller is destroyed
+  $scope.$on('$destroy', function (event){
+    chatService.removeAllListeners();
+  });
+
+});
+
+/*
+app.directive('chatmessage', function() {
+  return {
+    restrict: 'E',
+    controller: 'ChatCtrl',
+		templateUrl: 'views/chatmessage.html'
+	}
+});
+*/

--- a/client/index.html
+++ b/client/index.html
@@ -44,6 +44,7 @@
     <script type="text/javascript" src="controllers/usercontroller.js"></script>
     <script type="text/javascript" src="controllers/authcontroller.js"></script>
     <script type="text/javascript" src="controllers/chatcontroller.js"></script>
+    <script type="text/javascript" src="controllers/userlistcontroller.js"></script>
 
   </head>
 

--- a/client/services/chatservice.js
+++ b/client/services/chatservice.js
@@ -1,26 +1,11 @@
+app.factory('chatService', ['socketFactory', function(socketFactory){
+	
+	var chatIo = io.connect('http://127.0.0.1:3000/chat');
 
-app.factory('chatService', ['$rootScope', function($rootScope){
-	// setup chat connection and namespace
-	var chatConnection = io.connect('http://127.0.0.1:3000/chat');
+	var chatConnection = socketFactory({
+		ioSocket: chatIo
+	});
 
-	return {
-		on: function(event, callback){
-			chatConnection.on(event, function(){
-				var args = arguments;
-				$rootScope.$apply(function(){
-					callback.apply(chatConnection, args);
-				});
-			});
-		},
-		emit: function(event, data, callback) {
-			chatConnection.emit(event, data, function(){
-				var args = arguments;
-				$rootScope.$apply(function () {
-	  			if (callback) {
-	    			callback.apply(chatConnection, args);
-	  			}
-    		});
-			});
-		}
-	}
+	return chatConnection;
+
 }]);

--- a/client/services/mediaservice.js
+++ b/client/services/mediaservice.js
@@ -1,30 +1,11 @@
-app.factory('mediaService', ['$rootScope', function($rootScope) {
+app.factory('mediaService', ['$rootScope', 'socketFactory', function($rootScope, socketFactory) {
 
-	// setup media connection and namespace
-	var mediaConnection = io.connect('http://127.0.0.1:3000/media');
+	var mediaIo = io.connect('http://127.0.0.1:3000/media');
 
-	return {
+	var mediaConnection = socketFactory({
+		ioSocket: mediaIo
+	});
 
-		on: function(event, callback){
-			mediaConnection.on(event, function(){
+	return mediaConnection;
 
-				// updates templates
-				var args = arguments;
-				$rootScope.$apply(function(){
-					callback.apply(mediaConnection, args);
-				});
-			});
-		},
-		emit: function(event, data, callback) {
-			mediaConnection.emit(event, data, function(){
-				// updates templates
-				var args = arguments;
-				$rootScope.$apply(function () {
-    			if (callback) {
-      			callback.apply(mediaConnection, args);
-    			}
-    		});
-			});
-		}
-	}
 }]);

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -32,15 +32,15 @@ module.exports = function(io){
     });
 
     // send a message
-    socket.on('message', function(message){
+    socket.on('messageToServer', function(message){
 
       var chatPayload = {
         sender: socketIdUserMap[socket.id],
         timestamp: new Date(),
         message: message
       };
-      socket.emit('message', chatPayload);
-      //chatManager.emit('message', chatPayload);
+      //socket.broadcast.emit('messageFromServer', chatPayload);
+      chatManager.emit('messageFromServer', chatPayload);
 
       console.log('Chat: ', chatPayload.timestamp, chatPayload.sender, chatPayload.message);
     });


### PR DESCRIPTION
Fixed issue where two chat messages were being received.

Issue was being caused by using `ChatCtrl` twice and each using `chatManager`. When this happened, event listeners were being registered twice, which caused each callback to happen twice as well. The fix was to create a new controller just for the userlist directive, and make sure each socket event was listened to only once.
