### PR TITLE
update/send out user list when guest joins

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -34,6 +34,9 @@ module.exports = function(io){
 
     socket.emit('motd', 'Welcome to Lifeboat');
 
+    // update/send userList when guest joins (on socket connection and before user join)
+    updateUserList();
+
     // join the chatroom
     socket.on('join', function(username){
 


### PR DESCRIPTION
When a guest joins (on socket connection but before user joining), server will update and emit the user list. This should allow the userList to be viewed by a guest when first visiting the site. Before, it would take another user's action before the list was emitted and the guest could see it.
